### PR TITLE
Clean text better function

### DIFF
--- a/clean_text.py
+++ b/clean_text.py
@@ -1,47 +1,86 @@
 import nltk
 import string
+import re
 
-nltk.download('stopwords')
-from nltk.corpus import stopwords 
+def contains(str, seq):
+  '''Verify if a string (str) contains any of the characaters in a list.
+  
+  Args:
+    str: string
+    seq: list of characters
+  
+  Returns:
+    0 if the string does not contain any of the characters, 1 otherwise.
+  '''
+    for c in seq:
+        if c in str: 
+          return 1
+    return 0
 
-stop_words = set(stopwords.words('english'))
-personal_stop_words = ('rarα', 'aacr', 'aacs', 'aafc', 'aafp', 'aafps', 'aagm', 'aaipi', 'aalp',
-                       'aamdsif', 'aame', 'aaml', 'aams', 'aamt', 'aapc', 
-                       'aatc', 'aato', 'abcc', 'abcg', 'abcm', 'abfm', 'ablb', 'ablc', 'abmt',
-                       'abmts', 'abvd', 'accs', 'acsdkp', 'acsl', 'acsls', 'acta', 'actb', 'actd',
-                       'acted', 'actg', 'acth', 'actiii', 'acpd', 'adbw', 'adcc', 'adcp', 'adcr',
-                       'adcs', 'advp', 'adzuki', 'aefp', 'ahas', 'ahbi', 'ahcc', 'ahct', 'ahead',
-                       'ahfrt', 'ahnmd', 'ahnmds', 'ahsct', 'ahsp', 'aicar', 'aicda', 'aics', 'aida', 'aide'
-                       'µmlchip', 'özen', 'černjavski', 'αenac', 'αgalcer', 'αiib', 'αsma', 'αβtcr',
-                       'βcatenin', 'βphosphorylated', 'βtcr', 'δcak', 'δfret', 'δtcpc', 'μgrna', 'μmol', 'τhis')
 
-fix_typos_dict = {'remarkablely': 'remarkably',
-                  'leukaemia': 'leukemia',
-                  'leukaemias': 'leukemias',
-                  'efficiacy': 'efficiency',
-}
+def write_file(text):
+  '''Write the result (word_list) of cleaning function into a .txt file, called "results_file_clean.txt"
 
-##todo
-#join words: Meridianin D = Meridianin-D#
-#ara c : ara-c
+  Args: 
+    text: all pre-processed text 
+  '''
+  with open("results_file_clean.txt", "w", encoding="utf-8") as outfile:
+    outfile.write("\n".join(text))
 
-for i in personal_stop_words:
-    stop_words.add(i)
 
-# define training data
-summaries = [s.strip() for s in open("results_file.txt", encoding="utf-8")]
+def clean_file(file_path):
+  '''Pre-process text file with all the articles abstracts. This function removes from text stop words, units, 
+  symbols, punctuation and unwanted regular expressions and isolated numbers from the text. It uses the two other 
+  functions above.
 
-word_list = []
-for s in summaries:
-    s = s.split(' ')
-    s = [word for word in s if word.isalpha()]
-    s = [w.lower().translate({ord(x): '' for x in string.punctuation}) for w in s]
-    #s = [w for w in s if len(w) >= 4]
-    s = [w for w in s if not w in stop_words]
-    s = [w if w not in fix_typos_dict else fix_typos_dict[w] for w in s]
-    word_list.append(s)
+  Args:
+    file_path: the path of the original .txt file. 
+  '''
+  nltk.download('stopwords')
+  from nltk.corpus import stopwords 
 
-res = list(map(' '.join, word_list))
+  stop_words = set(stopwords.words('english'))
+  personal_stop_words = ('aafp', 'aagm', 'aaipi', 'aamdsif', 'aapc', 
+                         'abfm', 'abmts', 'acted', 'µmlchip', 'özen', 
+                         'černjavski', 'δcak', 'δfret', 'δtcpc')
 
-with open("results_file_clean.txt", "w", encoding="utf-8") as outfile:
-    outfile.write("\n".join(res))
+  fix_typos_dict = {'remarkablely': 'remarkably',
+                    'leukaemia': 'leukemia',
+                    'leukaemias': 'leukemias',
+                    'efficiacy': 'efficiency',
+                    'carboxylpheny': 'carboxyphenyl',
+                    'dimethylthiazole': 'dimethylthiazol',
+  }
+
+  units_and_symbols = ['μ', 'Ω', 'ω', 'μm', 'mol', '°c', '≥', '≤', '±', 
+                       'day', 'month', 'year', '·', 'week', 'μ', 'days',
+                       'weeks', 'years', 'mg', 'mm', '®', 'µl'
+  ]
+
+  for i in personal_stop_words:
+      stop_words.add(i)
+
+  # define training data
+  summaries = [s.strip() for s in open(file_path, encoding="utf-8")]
+  remove_chars = list(string.punctuation)
+  remove_chars.remove('-')
+
+  word_list = []
+  for s in summaries:
+      s = re.sub('<[^>]+>', '', s)
+      s = re.sub('\\s+', ' ', s)
+      s = re.sub('([--:\w?@%&+~#=]*\.[a-z]{2,4}\/{0,2})((?:[?&](?:\w+)=(?:\w+))+|[--:\w?@%&+~#=]+)?', '', s)
+      s = re.sub('\d+\W+\d+', '', s)
+      s = s.split(' ')
+      s = [w.lower().translate({ord(x): '' for x in remove_chars}) for w in s]
+      s = [w for w in s if not w.isdigit()]
+      s = [w for w in s if contains(w, units_and_symbols)==0]
+      s = [w for w in s if not w in stop_words]
+      s = [w if w not in fix_typos_dict else fix_typos_dict[w] for w in s]
+      word_list.append(s)
+
+  res = list(map(' '.join, word_list))
+  write_file(res)
+
+
+clean_file('results_file.txt')


### PR DESCRIPTION
A função de limpeza do texto foi alterada.
Algumas palavras que eram consideradas _stop words_ foram removidas dessa lista, pois descobriu-se que elas eram, na verdade, abreviações de doenças, drogas e/ou compostos químicos. Foram deixadas apenas siglas de eventos, simpósios e coisas do tipo.

Além disso, mais dois novos itens foram adicionados no dicionário _fix_typos_dict_.

Foi criada uma nova lista - _units_and_symbols_ -, que armazena diversos itens referentes a unidades de medida e outros símbolos indesejados. Qualquer palavra que contenha algum desses itens será removida posteriormente.

O caractere "-" foi removido da lista _string.punctuation_, assim, as palavras que o contém não serão descartadas. Isso foi feito pois existiam muitas palavras importantes (remédios, drogas, proteínas) com esse símbolo.

Dentro do loop de iteração/limpeza, foram adicionadas expressões regulares para eliminar padrões de texto não desejados - links, texto entre tags ("<" e ">") e palavras formadas apenas por números e caracteres não alfabéticos. Foram removidas também palavras formadas apenas por números e palavras que contenham qualquer caractere da lista _units_and_symbols_.

Por fim, o código foi todo modularizado (dividido em métodos), todos com descrição/explicação.